### PR TITLE
Thêm API size, color và khai báo type size, color, category

### DIFF
--- a/src/services/color.service.ts
+++ b/src/services/color.service.ts
@@ -1,0 +1,31 @@
+import { COLOR_ENDPOINT } from '~/constants/endPoint';
+import { IAxiosResponse } from '~/types/AxiosResponse';
+import { IColor, IColorFormData, IColorResponse } from '~/types/Color';
+import instance from '~/utils/api/axiosIntance';
+import { Params } from 'react-router-dom';
+
+const colorService = {
+    async getAll(params: Params) {
+        const res = await instance.get<IAxiosResponse<IColorResponse>>(`${COLOR_ENDPOINT.ALL}`, { params });
+        return res.data;
+    },
+    async getAllColors() {
+        const res = await instance.get<IAxiosResponse<IColorResponse>>(`${COLOR_ENDPOINT.ALL}`);
+        return res.data;
+    },
+    async createColor(payload: IColorFormData) {
+        const res = await instance.post<IAxiosResponse<IColor>>(`${COLOR_ENDPOINT.CREATE}`, payload);
+        return res.data;
+    },
+    async updateColor(id: string, payload: IColorFormData) {
+        const res = await instance.patch<IAxiosResponse<IColor>>(`${COLOR_ENDPOINT.UPDATE}/${id}`, payload);
+        return res.data;
+    },
+
+    async getDetail(id: string) {
+        const res = await instance.get<IAxiosResponse<IColor>>(`${COLOR_ENDPOINT.DETAIL}/${id}`);
+        return res.data;
+    },
+};
+
+export default colorService;

--- a/src/services/size.service.ts
+++ b/src/services/size.service.ts
@@ -1,0 +1,31 @@
+import { SIZE_ENDPOINT } from '~/constants/endPoint';
+import { IAxiosResponse } from '~/types/AxiosResponse';
+import { ISize, ISizeFormData, ISizeResponse } from '~/types/Size';
+import instance from '~/utils/api/axiosIntance';
+import { Params } from 'react-router-dom';
+
+const sizeService = {
+    async getAll(params: Params) {
+        const res = await instance.get<IAxiosResponse<ISizeResponse>>(`${SIZE_ENDPOINT.ALL}`, { params });
+        return res.data;
+    },
+    async getAllSizes() {
+        const res = await instance.get<IAxiosResponse<ISizeResponse>>(`${SIZE_ENDPOINT.ALL}`);
+        return res.data;
+    },
+    async createSize(payload: ISizeFormData) {
+        const res = await instance.post<IAxiosResponse<ISize>>(`${SIZE_ENDPOINT.CREATE}`, payload);
+        return res.data;
+    },
+    async updateSize(id: string, payload: ISizeFormData) {
+        const res = await instance.patch<IAxiosResponse<ISize>>(`${SIZE_ENDPOINT.UPDATE}/${id}`, payload);
+        return res.data;
+    },
+
+    async getDetail(id: string) {
+        const res = await instance.get<IAxiosResponse<ISize>>(`${SIZE_ENDPOINT.DETAIL}/${id}`);
+        return res.data;
+    },
+};
+
+export default sizeService;

--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -1,0 +1,23 @@
+export interface ICategoryPopular {
+    totalProducts?: number;
+    categoryId: string;
+    categoryName: string;
+    image: string;
+}
+export interface ICategory {
+    _id: string;
+    name: string;
+}
+
+export type ICategoryResponse = {
+    categories: ICategory[];
+    page: number;
+    totalDocs: number;
+    totalPages: number;
+};
+
+export interface ICategoryFormData {
+    name: string;
+}
+
+export type IMenu = { name: string; _id: string };

--- a/src/types/Color.ts
+++ b/src/types/Color.ts
@@ -1,0 +1,16 @@
+import { ICategory, ICategoryFormData } from './Category';
+
+export interface IColor extends ICategory {
+    hex: string;
+}
+
+export type IColorResponse = {
+    colors: IColor[];
+    page: number;
+    totalDocs: number;
+    totalPages: number;
+};
+
+export interface IColorFormData extends ICategoryFormData {
+    hex: string;
+}

--- a/src/types/Size.ts
+++ b/src/types/Size.ts
@@ -1,0 +1,12 @@
+import { ICategory, ICategoryFormData } from './Category';
+
+export interface ISize extends ICategory {}
+
+export type ISizeResponse = {
+    sizes: ISize[];
+    page: number;
+    totalDocs: number;
+    totalPages: number;
+};
+
+export interface ISizeFormData extends ICategoryFormData {}


### PR DESCRIPTION
- Thêm service API cho size và color (`size.service.ts`, `color.service.ts`)
- Khai báo interface/type cho size, color, category
- Tách các interface ra thành các file riêng để dễ quản lý